### PR TITLE
Allow putting keyword lists in as metadata/avoids regression

### DIFF
--- a/lib/bugsnex.ex
+++ b/lib/bugsnex.ex
@@ -40,9 +40,13 @@ defmodule Bugsnex do
 
   @metadata_key "bugsnex_metadata"
   def get_metadata do
-    (Process.get(@metadata_key) || %{}) |> Enum.into(Map.new)
+    (Process.get(@metadata_key) || %{}) |> Enum.into(%{})
   end
 
+  def put_metadata(keyword_list) when is_list(keyword_list) do
+    map = Enum.into(keyword_list, %{})
+    put_metadata(map)
+  end
   def put_metadata(dict) do
     Process.put(@metadata_key, Map.merge(get_metadata(), dict))
   end

--- a/test/bugsnex_test.exs
+++ b/test/bugsnex_test.exs
@@ -53,6 +53,14 @@ defmodule BugsnexTest do
     assert Bugsnex.get_metadata.user == 123
   end
 
+  test ".put_metadata works with keyword list (regression)" do
+    Bugsnex.put_metadata(foo: "bar")
+    spawn_link fn ->
+      Bugsnex.put_metadata(user: 678)
+      assert Bugsnex.get_metadata.user == 678
+    end
+    assert Bugsnex.get_metadata.foo == "bar"
+  end
 
   test "track_deploy sends a deploy notification to the api" do
     Bugsnex.track_deploy()


### PR DESCRIPTION
Basically someone was too eagerly removing deprecation warnings and we didn't have a test case to cover this usage, which we do from our own apps :frowning_face: 