### PR TITLE
Fix/support file uploads

### DIFF
--- a/lib/bugsnex/plug.ex
+++ b/lib/bugsnex/plug.ex
@@ -82,6 +82,11 @@ defmodule Bugsnex.Plug do
     do_filter(params, Application.get_env(:bugsnex, :filter_params, @default_filter_params))
   end
 
+  defp do_filter(%{__struct__: _} = map, filter_params) do
+    map
+    |> Map.from_struct
+    |> do_filter(filter_params)
+  end
   defp do_filter(%{} = map, filter_params) do
     Enum.into map, %{}, fn {key, value} ->
       if Enum.member?(filter_params, key) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Bugsnex.Mixfile do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.3.1"
   def project do
     [app: :bugsnex,
      version: @version,
@@ -36,7 +36,7 @@ defmodule Bugsnex.Mixfile do
 
   # Dependencies can be Hex packages:
   #
-  #   {:mydep, "~> 0.3.0"}
+  #   {:mydep, "~> 0.3.1"}
   #
   # Or git/path repositories:
   #

--- a/test/bugsnex/plug_test.exs
+++ b/test/bugsnex/plug_test.exs
@@ -86,6 +86,20 @@ defmodule Bugsnex.PlugTest do
     assert plug_env == Bugsnex.Plug.build_plug_env(conn)
   end
 
+  test "build_plug_env/2 also filters a file upload" do
+    params =  %{
+      foo: "bar",
+      file: %Plug.Upload{content_type: "text/csv", filename: "test.csv", path: "/path/to/tempfile"}
+    }
+    conn = conn(:get, "/bang", params)
+    plug_env = %{request: Bugsnex.Plug.build_request_data(conn),
+                 context: "/bang",
+                 params: %{"foo" => "bar", "file" => %{:content_type => "text/csv", :filename => "test.csv", :path => "/path/to/tempfile"}},
+                 session: %{}}
+
+    assert plug_env == Bugsnex.Plug.build_plug_env(conn)
+  end
+
   test "build_plug_env/2 also filters a list" do
     params =  %{"foo" => [%{"password_confirmation" => "secret"}]}
 


### PR DESCRIPTION
As `Plug.Upload` is returning a struct `do_filter` failed with `(Protocol.UndefinedError) protocol Enumerable not implemented for %Plug.Upload{content_type: "text/csv", filename: "test.csv", path: "/path/to/tempfile"}` if errors occur for a file upload request.

This pull request add general support for structs, which covers file uploads as well.