### PR TITLE
Fix deprecation warnings related to GenEvent and GenServer

### DIFF
--- a/lib/bugsnex/logger.ex
+++ b/lib/bugsnex/logger.ex
@@ -1,9 +1,8 @@
 defmodule Bugsnex.Logger do
   import Bugsnex.Util
-  use GenEvent
+  @behaviour :gen_event
 
-
-  def init(_mod, []), do: {:ok, []}
+  def init([]), do: {:ok, []}
 
   def handle_call({:configure, new_keys}, _state) do
     {:ok, :ok, new_keys}

--- a/test/support/test_api.ex
+++ b/test/support/test_api.ex
@@ -1,6 +1,8 @@
 defmodule Bugsnex.TestApi do
   use GenServer
 
+  def init(init_arg), do: {:ok, init_arg}
+
   def start_link do
     GenServer.start_link(__MODULE__, %{crash: false, subscribers: []}, name: __MODULE__)
   end


### PR DESCRIPTION
Fixes the following deprecation warning:

```bash
warning: function init/1 required by behaviour GenServer is not implemented (in module Bugsnex.TestApi).

We will inject a default implementation for now:

    def init(init_arg) do
      {:ok, init_arg}
    end

You can copy the implementation above or define your own that converts the arguments given to GenServer.start_link/3 to the server state.

  test/support/test_api.ex:1

warning: the GenEvent module is deprecated, see its documentation for alternatives
  lib/bugsnex/logger.ex:3

warning: GenEvent.__using__/1 is deprecated. Use one of the alternatives described in the documentation for the GenEvent module
  lib/bugsnex/logger.ex:3
```