### PR TITLE
Updated version to 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 
      ```elixir
      def deps do
-       [{:bugsnex, "~> 0.3.1"}]
+       [{:bugsnex, "~> 0.4.1"}]
      end
      ```
 


### PR DESCRIPTION
I think this update in the readme is missing. Still links to the old version.