### PR TITLE
Filters everything that is below status code 500

### DIFF
--- a/lib/bugsnex/plug.ex
+++ b/lib/bugsnex/plug.ex
@@ -18,6 +18,12 @@ defmodule Bugsnex.Plug do
       end
 
       defp handle_errors(conn, %{kind: _kind, reason: exception, stack: stack}) do
+        do_handle_errors(conn, exception, stack)
+      end
+
+      defp do_handle_errors(_, %{plug_status: status}, _) when status < 500, do: :ok
+
+      defp do_handle_errors(conn, exception, stack) do
         metadata = conn
           |> build_plug_env
           |> Map.merge(Bugsnex.get_metadata())

--- a/test/bugsnex/plug_test.exs
+++ b/test/bugsnex/plug_test.exs
@@ -18,6 +18,11 @@ defmodule Bugsnex.PlugTest do
       _ = conn
       raise RuntimeError, "Oops"
     end
+
+    get "/non_important_bang" do
+      _ = conn
+      raise %Plug.BadRequestError{}
+    end
   end
 
 
@@ -40,6 +45,13 @@ defmodule Bugsnex.PlugTest do
     catch_error(PlugApp.call conn, [])
 
     assert_receive({:notice_sent, _notice})
+  end
+
+  test "exceptions that have a plug status of < 500 are ignored" do
+    conn = conn(:get, "/non_important_bang")
+    catch_error(PlugApp.call(conn, []))
+
+    refute_receive({:notice_sent, _notice})
   end
 
   test "sends metadata to bugsnag" do


### PR DESCRIPTION
This is how appsignal and others do the error handling in elixir.
Maybe there are use cases where the < 500 errors should be reported. If
there are, you can easily add your own error handlers for specific ones
or we need to modify the code here to make it configurable.

Ah and this PR also reformats using the elixir formatter. If you don't like it I will have to redo the PR and disable the auto format in my VS Code :trollface: .

closes #36