### PR TITLE
Fix ci setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ otp_release:
   - 18.3
   - 19.3
   - 20.3
+dist: trusty
 
 matrix:
   exclude:


### PR DESCRIPTION
https://travis-ci.community/t/erlang-18-3-couldnt-be-pulled/3836/4

> ... the failing one (as shown in the logs) is using Xenial (16.04), which doesn’t have 18.3. We are moving the default to Xenial gradually.