### PR TITLE
Support runtime configuration for api_key and release_stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,41 @@ elixir:
   - 1.6.6
   - 1.7.4
   - 1.8.0
+  - 1.9.1
 otp_release:
   - 18.3
   - 19.3
   - 20.3
+  - 22.0
 dist: trusty
 
 matrix:
   exclude:
   - elixir: 1.4.5
     otp_release: 20.3
+  - elixir: 1.4.5
+    otp_release: 22.0
   - elixir: 1.5.3
     otp_release: 20.3
+  - elixir: 1.5.3
+    otp_release: 22.0
   - elixir: 1.6.6
     otp_release: 20.3
+  - elixir: 1.6.6
+    otp_release: 22.0
   - elixir: 1.7.4
     otp_release: 18.3
+  - elixir: 1.7.4
+    otp_release: 22.0
   - elixir: 1.8.0
     otp_release: 18.3
   - elixir: 1.8.0
     otp_release: 19.3
+  - elixir: 1.9.1
+    otp_release: 18.3
+  - elixir: 1.9.1
+    otp_release: 19.3
+
 
 script:
   - if [[ `elixir -v` = *"1.6"* ]]; then mix format --check-formatted; fi

--- a/lib/bugsnex/notice.ex
+++ b/lib/bugsnex/notice.ex
@@ -2,12 +2,9 @@ defmodule Bugsnex.Notice do
   alias Bugsnex.Stacktrace
 
   @payload_version "2"
-  @api_key Application.get_env(:bugsnex, :api_key)
-  @release_stage Application.get_env(:bugsnex, :release_stage)
-  @app %{releaseStage: @release_stage}
   @system Application.get_env(:bugsnex, :system_module, Bugsnex.System)
 
-  defstruct apiKey: @api_key,
+  defstruct apiKey: nil,
             notifier: %{
               name: "Bugsnex",
               version: Bugsnex.Mixfile.project()[:version],
@@ -21,7 +18,9 @@ defmodule Bugsnex.Notice do
             metaData: nil
 
   def new(exception, stacktrace, metadata) do
-    %__MODULE__{}
+    %__MODULE__{
+      apiKey: Application.get_env(:bugsnex, :api_key)
+    }
     |> add_event(%{exception: exception, stacktrace: stacktrace, metadata: metadata})
   end
 
@@ -32,7 +31,7 @@ defmodule Bugsnex.Notice do
   def event_data(%{exception: exception, stacktrace: stacktrace, metadata: metadata}) do
     %{
       payloadVersion: @payload_version,
-      app: @app,
+      app: %{releaseStage: Application.get_env(:bugsnex, :release_stage)},
       exceptions: [exception_data(exception, stacktrace)]
     }
     |> add_metadata(metadata)

--- a/test/bugsnex/notice_test.exs
+++ b/test/bugsnex/notice_test.exs
@@ -82,4 +82,21 @@ defmodule Bugsnex.NoticeTest do
     {:ok, hostname} = :inet.gethostname()
     assert defaults == %{host: to_string(hostname)}
   end
+
+  test "new notice supports runtime configuration" do
+    old_api_key = Application.get_env(:bugsnex, :api_key)
+    old_release_stage = Application.get_env(:bugsnex, :release_stage)
+
+    Application.put_env(:bugsnex, :api_key, "TEST_API_KEY_OVERRIDE")
+    Application.put_env(:bugsnex, :release_stage, "TEST_RELEASE_STAGE_OVERRIDE")
+
+    notice = Notice.new(@exception, @stacktrace, @metadata)
+    [event] = notice.events
+
+    assert notice.apiKey == "TEST_API_KEY_OVERRIDE"
+    assert event.app.releaseStage == "TEST_RELEASE_STAGE_OVERRIDE"
+
+    Application.put_env(:bugsnex, :api_key, old_api_key)
+    Application.put_env(:bugsnex, :release_stage, old_release_stage)
+  end
 end


### PR DESCRIPTION
Right now `api_key` and `release_stage` are resolved at compile time (when `Bugsnex.Notice` is compiled). This makes it impossible to configure these values at runtime, e.g. when configuring Distillery or new Elixir releases via environment variables. 